### PR TITLE
EXR Support for rendered images

### DIFF
--- a/mandelbulber2/Debug/mandelbulber.pro
+++ b/mandelbulber2/Debug/mandelbulber.pro
@@ -45,6 +45,7 @@ SOURCES +=  ../src/algebra.cpp\
 	    	../src/primitives.cpp\
 			../src/progress_text.cpp\
 			../src/preview_file_dialog.cpp\
+                        ../src/exr_file_dialog.cpp\
 			../src/random.cpp\
 	    	../src/render_image.cpp\
 	    	../src/rendered_image_widget.cpp\
@@ -85,6 +86,7 @@ HEADERS  += ../src/render_window.hpp\
 			../qt/myhistogramlabel.h\
 			../src/my_ui_loader.h\
 			../src/preview_file_dialog.h\
+                        ../src/exr_file_dialog.h\
 			../src/ssao_worker.h\
 			../qt/color_palette_widget.h\
 			../src/rendered_image_widget.hpp\
@@ -113,9 +115,9 @@ QMAKE_CXXFLAGS_RELEASE += -O3
  
 QMAKE_LFLAGS_RELEASE -= -O1 -fopenmp
 
-QMAKE_CXXFLAGS += -msse2 -ffast-math -fopenmp
+QMAKE_CXXFLAGS += -msse2 -ffast-math -fopenmp -lIlmImf
 
-LIBS += -lpng -lgsl -lgslcblas -fopenmp
+LIBS += -lpng -lgsl -lgslcblas -fopenmp -lIlmImf
 win32:LIBS += -lz
 
 # rh: ugly absolute paths for libpng and libjpeg on my windows system
@@ -124,3 +126,5 @@ win32:LIBS += -lz
 win32:greaterThan(QT_MAJOR_VERSION, 4): INCLUDEPATH += "C:/Qt/Tools/mingw48_32/include/libpng16"
 #win32:LIBS += "C:/Qt/Tools/mingw48_32/lib/libpng16"
 #win32:INCLUDEPATH += "C:/Qt/Tools/mingw48_32/include/libpng16"
+
+INCLUDEPATH += "/usr/include/OpenEXR"

--- a/mandelbulber2/qt/render_window.ui
+++ b/mandelbulber2/qt/render_window.ui
@@ -217,6 +217,7 @@
     <addaction name="actionSave_as_PNG"/>
     <addaction name="actionSave_as_PNG_16_bit"/>
     <addaction name="actionSave_as_PNG_16_bit_with_alpha_channel"/>
+    <addaction name="actionSave_as_EXR"/>
    </widget>
    <widget class="QMenu" name="menuFile">
     <property name="title">
@@ -10733,6 +10734,15 @@ and water):</string>
    </property>
    <property name="text">
     <string>Save as PNG 16 bit with alpha channel</string>
+   </property>
+  </action>
+  <action name="actionSave_as_EXR">
+   <property name="icon">
+    <iconset theme="document-save-as" resource="icons.qrc">
+     <normaloff>:/system/icons/document-save-as.svg</normaloff>:/system/icons/document-save-as.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Save as EXR</string>
    </property>
   </action>
   <action name="actionLoad_settings">

--- a/mandelbulber2/src/exr_file_dialog.cpp
+++ b/mandelbulber2/src/exr_file_dialog.cpp
@@ -1,0 +1,71 @@
+/**
+ * Mandelbulber v2, a 3D fractal generator
+ *
+ * EXRFileDialog class - extension of QFileDialog class to store EXR Image files
+ *
+ * Copyright (C) 2014 Krzysztof Marczak
+ *
+ * This file is part of Mandelbulber.
+ *
+ * Mandelbulber is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Mandelbulber is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should have received a copy of the GNU
+ * General Public License along with Mandelbulber. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors: Sebastian Jennen (sebastian.jennen@gmx.de)
+ */
+
+#include "exr_file_dialog.h"
+#include <QGridLayout>
+
+EXRFileDialog::EXRFileDialog(QWidget *parent) : QFileDialog(parent)
+{
+	setOption(QFileDialog::DontUseNativeDialog);
+	vboxlayout = new QVBoxLayout();
+
+	checkboxRGB = new QCheckBox(tr("RGB"));
+	checkboxRGB->setChecked(true);
+
+	checkboxAlpha = new QCheckBox(tr("Alpha"));
+	checkboxAlpha->setChecked(true);
+
+	checkboxZBuffer = new QCheckBox(tr("Z Buffer"));
+	checkboxZBuffer->setChecked(true);
+
+	info = new QLabel("");
+	vboxlayout->addWidget(checkboxRGB);
+	vboxlayout->addWidget(checkboxAlpha);
+	vboxlayout->addWidget(checkboxZBuffer);
+	vboxlayout->addWidget(info);
+	vboxlayout->addStretch();
+
+	//add to existing layout
+	QGridLayout *gridlayout = (QGridLayout*)this->layout();
+	gridlayout->addLayout(vboxlayout, 1, 3, 3, 1);
+}
+
+EXRFileDialog::~EXRFileDialog()
+{
+	delete vboxlayout;
+	delete info;
+}
+
+bool EXRFileDialog::rgbChannel()
+{
+	return checkboxRGB->isChecked();
+}
+
+bool EXRFileDialog::alphaChannel()
+{
+	return checkboxAlpha->isChecked();
+}
+
+bool EXRFileDialog::zBufferChannel()
+{
+	return checkboxZBuffer->isChecked();
+}

--- a/mandelbulber2/src/exr_file_dialog.h
+++ b/mandelbulber2/src/exr_file_dialog.h
@@ -1,0 +1,52 @@
+/**
+ * Mandelbulber v2, a 3D fractal generator
+ *
+ * EXRFileDialog class - extension of QFileDialog class to store EXR Image files
+ *
+ * Copyright (C) 2014 Krzysztof Marczak
+ *
+ * This file is part of Mandelbulber.
+ *
+ * Mandelbulber is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Mandelbulber is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details. You should have received a copy of the GNU
+ * General Public License along with Mandelbulber. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors: Sebastian Jennen (sebastian.jennen@gmx.de)
+ */
+
+#ifndef EXRFILEDIALOG_H_
+#define EXRFILEDIALOG_H_
+
+#include <QFileDialog>
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QCheckBox>
+
+class EXRFileDialog: public QFileDialog
+{
+		Q_OBJECT
+
+public:
+		EXRFileDialog(QWidget *parent);
+		~EXRFileDialog();
+		bool rgbChannel();
+		bool alphaChannel();
+		bool zBufferChannel();
+
+private:
+		QVBoxLayout* vboxlayout;
+		QCheckBox *checkboxRGB;
+		QCheckBox *checkboxAlpha;
+		QCheckBox *checkboxZBuffer;
+
+protected:
+		QLabel *info;
+};
+
+#endif /* EXRFILEDIALOG_H_ */

--- a/mandelbulber2/src/files.h
+++ b/mandelbulber2/src/files.h
@@ -53,6 +53,7 @@ void BufferNormalize16(sRGB16 *buffer, unsigned int size);
 //void SaveAllImageLayers(const char *filename, cImage *image);
 std::string removeFileExtension(const std::string &filename);
 
+void SaveEXR(QString filename, int width, int height, cImage* image, bool rgbChannel, bool alphaChannel, bool zBufferChannel);
 bool SaveJPEGQt(QString filename, unsigned char *image, int width, int height, int quality);
 
 #endif /* FILES_H_ */

--- a/mandelbulber2/src/interface.cpp
+++ b/mandelbulber2/src/interface.cpp
@@ -206,6 +206,7 @@ void cInterface::ConnectSignals(void)
 	QApplication::connect(mainWindow->ui->actionSave_as_PNG, SIGNAL(triggered()), mainWindow, SLOT(slotMenuSaveImagePNG8()));
 	QApplication::connect(mainWindow->ui->actionSave_as_PNG_16_bit, SIGNAL(triggered()), mainWindow, SLOT(slotMenuSaveImagePNG16()));
 	QApplication::connect(mainWindow->ui->actionSave_as_PNG_16_bit_with_alpha_channel, SIGNAL(triggered()), mainWindow, SLOT(slotMenuSaveImagePNG16Alpha()));
+	QApplication::connect(mainWindow->ui->actionSave_as_EXR, SIGNAL(triggered()), mainWindow, SLOT(slotMenuSaveImageEXR()));
 	QApplication::connect(mainWindow->ui->actionAbout_Qt, SIGNAL(triggered()), mainWindow, SLOT(slotMenuAboutQt()));
 	QApplication::connect(mainWindow->ui->actionAbout_Mandelbulber, SIGNAL(triggered()), mainWindow, SLOT(slotMenuAboutMandelbulber()));
 	QApplication::connect(mainWindow->ui->actionUndo, SIGNAL(triggered()), mainWindow, SLOT(slotMenuUndo()));

--- a/mandelbulber2/src/render_window.cpp
+++ b/mandelbulber2/src/render_window.cpp
@@ -43,6 +43,7 @@
 #include "common_math.h"
 #include "my_ui_loader.h"
 #include "preview_file_dialog.h"
+#include "exr_file_dialog.h"
 #include "global_data.hpp"
 
 #include "progress_text.hpp"
@@ -763,6 +764,31 @@ void RenderWindow::slotMenuSaveImagePNG16Alpha()
 		gApplication->processEvents();
 		SavePNG16Alpha(filename, gMainInterface->mainImage->GetWidth(), gMainInterface->mainImage->GetHeight(), gMainInterface->mainImage);
 		ProgressStatusText(tr("Saving image to %1 ...").arg("16-bit PNG + alpha channel"), tr("Saving PNG image started"), 1.0, ui->statusbar, gMainInterface->progressBar);
+		gApplication->processEvents();
+		systemData.lastImageFile = filename;
+	}
+}
+
+void RenderWindow::slotMenuSaveImageEXR()
+{
+	EXRFileDialog dialog(this);
+	dialog.setFileMode(QFileDialog::AnyFile);
+	dialog.setNameFilter(tr("EXR images (*.exr)"));
+	dialog.setDirectory(QFileInfo(systemData.lastImageFile).absolutePath());
+	dialog.selectFile(QFileInfo(systemData.lastImageFile).completeBaseName());
+	dialog.setAcceptMode(QFileDialog::AcceptSave);
+	dialog.setWindowTitle(tr("Save image to %1 file...").arg("EXR"));
+	dialog.setDefaultSuffix("exr");
+	QStringList filenames;
+	if(dialog.exec())
+	{
+		filenames = dialog.selectedFiles();
+		QString filename = filenames.first();
+		ProgressStatusText(tr("Saving %1 image").arg("EXR"), tr("Saving EXR image started"), 0.0, ui->statusbar, gMainInterface->progressBar);
+		gApplication->processEvents();
+		SaveEXR(filename, gMainInterface->mainImage->GetWidth(), gMainInterface->mainImage->GetHeight(),
+		gMainInterface->mainImage, dialog.rgbChannel(), dialog.alphaChannel(), dialog.zBufferChannel());
+		ProgressStatusText(tr("Saving %1 image").arg("EXR"), tr("Saving EXR image finished"), 1.0, ui->statusbar, gMainInterface->progressBar);
 		gApplication->processEvents();
 		systemData.lastImageFile = filename;
 	}

--- a/mandelbulber2/src/render_window.hpp
+++ b/mandelbulber2/src/render_window.hpp
@@ -130,6 +130,7 @@ private slots:
 	void slotMenuSaveImagePNG16();
 	void slotMenuSaveImagePNG16Alpha();
 	void slotMenuSaveImagePNG8();
+	void slotMenuSaveImageEXR();
 	void slotMenuSaveSettings();
 	void slotMenuUndo();
 	void slotUpdateDocksandToolbarbyAction();


### PR DESCRIPTION
Before merge, please check Windows compatibility.

RGB, A and Z component can be saved individually.
Image format well suited for blender.

needs package libopenexr-dev
ugly path in .pro file needs to be fixed