### PR TITLE
Fix mismatched delete[]

### DIFF
--- a/mandelbulber2/src/audio_track.cpp
+++ b/mandelbulber2/src/audio_track.cpp
@@ -96,7 +96,7 @@ void cAudioTrack::LoadAudio(const QString &filename)
 				rawAudio[i] = sample;
 			}
 
-			delete tempBuff;
+			delete[] tempBuff;
 		}
 
 		sf_close(infile);


### PR DESCRIPTION
Fixes Clang warning

 'delete' applied to a pointer that was allocated with 'new';
 did you mean 'delete[]'? [-Wmismatched-new-delete]