### PR TITLE
Add explicit destructor for cPrimitives

### DIFF
--- a/mandelbulber2/src/primitives.cpp
+++ b/mandelbulber2/src/primitives.cpp
@@ -32,6 +32,8 @@
  * definitions of primitive objects
  */
 
+#include <QtAlgorithms>
+
 #include "primitives.h"
 #include "displacement_map.hpp"
 #include "parameters.hpp"
@@ -257,6 +259,11 @@ cPrimitives::cPrimitives(const cParameterContainer *par, QVector<cObjectData> *o
 	mRotAllPrimitivesRotation.SetRotation2(allPrimitivesRotation / 180.0 * M_PI);
 
 	WriteLog("cPrimitives::cPrimitives(const cParameterContainer *par) finished", 2);
+}
+
+cPrimitives::~cPrimitives()
+{
+	qDeleteAll(allPrimitives);
 }
 
 double sPrimitivePlane::PrimitiveDistance(CVector3 _point) const

--- a/mandelbulber2/src/primitives.h
+++ b/mandelbulber2/src/primitives.h
@@ -151,6 +151,7 @@ class cPrimitives
 
 public:
 	cPrimitives(const cParameterContainer *par, QVector<cObjectData> *obejctData = NULL);
+	~cPrimitives();
 	double TotalDistance(
 		CVector3 point, double fractalDistance, int *closestObjectId, sRenderData *data) const;
 


### PR DESCRIPTION
This is needed to avoid memory leaks of memory allocated with "new"
in the constructor.