### PR TITLE
Clean up some memory leaks

### DIFF
--- a/mandelbulber2/src/file_image.cpp
+++ b/mandelbulber2/src/file_image.cpp
@@ -1184,6 +1184,7 @@ bool ImageFileSaveTIFF::SaveTIFF(
 
 	TIFFWriteEncodedStrip(tiff, 0, (void *)colorPtr, tsize_t(width * height * pixelSize));
 	TIFFClose(tiff);
+	delete[] colorPtr;
 	return true;
 }
 

--- a/mandelbulber2/src/file_image.cpp
+++ b/mandelbulber2/src/file_image.cpp
@@ -249,17 +249,19 @@ void ImageFileSavePNG::SavePNG(
 	/* create file */
 	FILE *fp = fopen(filename.toLocal8Bit().constData(), "wb");
 	png_bytep *row_pointers = NULL;
+	png_structp png_ptr = NULL;
+	png_info *info_ptr = NULL;
 
 	try
 	{
 		if (!fp) throw QString("[write_png_file] File %s could not be opened for writing.");
 
 		/* initialize stuff */
-		png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+		png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
 
 		if (!png_ptr) throw QString("[write_png_file] png_create_write_struct failed");
 
-		png_info *info_ptr = png_create_info_struct(png_ptr);
+		info_ptr = png_create_info_struct(png_ptr);
 		if (!info_ptr) throw QString("[write_png_file] png_create_info_struct failed");
 
 		if (setjmp(png_jmpbuf(png_ptr))) throw QString("[write_png_file] Error during init_io");
@@ -483,12 +485,24 @@ void ImageFileSavePNG::SavePNG(
 		if (setjmp(png_jmpbuf(png_ptr))) throw QString("[write_png_file] Error during end of write");
 
 		png_write_end(png_ptr, info_ptr);
+		png_destroy_write_struct(&png_ptr, &info_ptr);
 		delete[] row_pointers;
 		if (colorPtr) delete[] colorPtr;
 		fclose(fp);
 	}
 	catch (QString &status)
 	{
+		if (png_ptr)
+		{
+			if (info_ptr)
+			{
+				png_destroy_write_struct(&png_ptr, &info_ptr);
+			}
+			else
+			{
+				png_destroy_write_struct(&png_ptr, NULL);
+			}
+		}
 		if (row_pointers) delete[] row_pointers;
 		if (fp) fclose(fp);
 		cErrorMessage::showMessage(
@@ -502,17 +516,19 @@ void ImageFileSavePNG::SavePNG16(QString filename, int width, int height, sRGB16
 	/* create file */
 	FILE *fp = fopen(filename.toLocal8Bit().constData(), "wb");
 	png_bytep *row_pointers = NULL;
+	png_structp png_ptr = NULL;
+	png_info *info_ptr = NULL;
 
 	try
 	{
 		if (!fp) throw QString("[write_png_file] File %s could not be opened for writing.");
 
 		/* initialize stuff */
-		png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+		png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
 
 		if (!png_ptr) throw QString("[write_png_file] png_create_write_struct failed");
 
-		png_info *info_ptr = png_create_info_struct(png_ptr);
+		info_ptr = png_create_info_struct(png_ptr);
 		if (!info_ptr) throw QString("[write_png_file] png_create_info_struct failed");
 
 		if (setjmp(png_jmpbuf(png_ptr))) throw QString("[write_png_file] Error during init_io");
@@ -543,13 +559,24 @@ void ImageFileSavePNG::SavePNG16(QString filename, int width, int height, sRGB16
 		if (setjmp(png_jmpbuf(png_ptr))) throw QString("[write_png_file] Error during end of write");
 
 		png_write_end(png_ptr, info_ptr);
-
+		png_destroy_write_struct(&png_ptr, &info_ptr);
 		delete[] row_pointers;
 
 		fclose(fp);
 	}
 	catch (QString &status)
 	{
+		if (png_ptr)
+		{
+			if (info_ptr)
+			{
+				png_destroy_write_struct(&png_ptr, &info_ptr);
+			}
+			else
+			{
+				png_destroy_write_struct(&png_ptr, NULL);
+			}
+		}
 		if (row_pointers) delete[] row_pointers;
 		if (fp) fclose(fp);
 		cErrorMessage::showMessage(
@@ -671,7 +698,7 @@ void ImageFileSavePNG::SaveFromTilesPNG16(const char *filename, int width, int h
 	}
 
 	png_write_end(png_ptr, info_ptr);
-
+	png_destroy_write_struct(&png_ptr, &info_ptr);
 	delete[] rowBuffer;
 	delete[] files;
 

--- a/mandelbulber2/src/files.cpp
+++ b/mandelbulber2/src/files.cpp
@@ -336,6 +336,7 @@ void SaveImage(QString filename, ImageFileSave::enumImageFileType filetype, cIma
 			SLOT(slotUpdateProgressAndStatus(const QString &, const QString &, double)));
 	}
 	imageFileSave->SaveImage();
+	delete imageFileSave;
 	// return SaveImage(fileWithoutExtension, filetype, image, imageConfig);
 }
 

--- a/mandelbulber2/src/files.cpp
+++ b/mandelbulber2/src/files.cpp
@@ -365,12 +365,14 @@ sRGBA16 *LoadPNG(QString filename, int &outWidth, int &outHeight)
 	if (bytesRead < 8)
 	{
 		fclose(fp);
+		png_destroy_read_struct(&png_ptr, NULL, NULL);
 		return NULL;
 	}
 
 	if (!png_check_sig(sig, 8))
 	{
 		fclose(fp);
+		png_destroy_read_struct(&png_ptr, NULL, NULL);
 		return NULL; /* bad signature */
 	}
 

--- a/mandelbulber2/src/netrender.cpp
+++ b/mandelbulber2/src/netrender.cpp
@@ -136,7 +136,12 @@ void CNetRender::DeleteClient()
 	if (deviceType != netRender_CLIENT) return;
 	deviceType = netRender_UNKNOWN;
 	WriteLog("NetRender - Delete Client", 2);
-	if (reconnectTimer->isActive()) reconnectTimer->stop();
+	if (reconnectTimer)
+	{
+		if (reconnectTimer->isActive()) reconnectTimer->stop();
+		delete reconnectTimer;
+		reconnectTimer = NULL;
+	}
 	if (clientSocket)
 	{
 		clientSocket->close();


### PR DESCRIPTION
In netrender.cpp, also check that reconnectTimer is not NULL before
stopping the timer, similar to how clientSocket is treated.

See also #167.