### PR TITLE
Remove unused sVectorsAround member notBlack

### DIFF
--- a/mandelbulber2/src/common_math.h
+++ b/mandelbulber2/src/common_math.h
@@ -58,7 +58,6 @@ struct sVectorsAround
 	int R;
 	int G;
 	int B;
-	bool notBlack;
 };
 
 struct sVector

--- a/mandelbulber2/src/render_worker.hpp
+++ b/mandelbulber2/src/render_worker.hpp
@@ -96,7 +96,6 @@ private:
 		int R;
 		int G;
 		int B;
-		bool notBlack;
 	};
 
 	struct sRayMarchingIn


### PR DESCRIPTION
This was spotted by UBsan:

   runtime error: load of value 190, which is not a valid value for type 'bool'

The field has never been used, so just remove it.