### PR TITLE
Add keyboard shortcuts for keyboard navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,18 @@ The possibilities are literally **infinite**!
 ![image](https://cloud.githubusercontent.com/assets/11696990/13788910/173cf11a-eae2-11e5-884e-f1d03924a5f3.png)
 ![image](https://cloud.githubusercontent.com/assets/11696990/16526853/a708e7e2-3fb3-11e6-8136-323bda493604.png)
 
-## Building and deploying 
+## Keyboard shortcuts
+
+In render window:
+
+  - <kbd>Up</kbd> / <kbd>Down</kbd>: move camera forward / backward
+  - <kbd>Left</kbd> / <kbd>Right</kbd>: move camera left / right
+  - <kbd>Ctrl</kbd>+(<kbd>Up</kbd> / <kbd>Down</kbd>): move camera up / down
+  - <kbd>Shift</kbd>+(<kbd>Up</kbd> / <kbd>Down</kbd> / <kbd>Left</kbd> / <kbd>Right</kbd>): rotate camera
+  - <kbd>Ctrl</kbd>+(<kbd>Left</kbd> / <kbd>Right</kbd>): roll camera left / right
+
+
+## Building and deploying
 
 Please see information in [mandelbulber2/deploy](mandelbulber2/deploy) folder.
 

--- a/mandelbulber2/src/animation_flight.cpp
+++ b/mandelbulber2/src/animation_flight.cpp
@@ -94,6 +94,8 @@ cFlightAnimation::cFlightAnimation(cInterface *_interface, cAnimationFrames *_fr
 			SLOT(slotMovedSliderLastFrame(int)));
 		connect(ui->tableWidget_flightAnimation, SIGNAL(cellDoubleClicked(int, int)), this,
 			SLOT(slotCellDoubleClicked(int, int)));
+		connect(mainInterface->renderedImage, SIGNAL(ShiftModeChanged(bool)), this,
+			SLOT(slotOrthogonalStrafe(bool)));
 
 		// connect renderedImage signals
 		connect(mainInterface->renderedImage, SIGNAL(StrafeChanged(CVector2<double>)), this,
@@ -107,8 +109,6 @@ cFlightAnimation::cFlightAnimation(cInterface *_interface, cAnimationFrames *_fr
 		connect(mainInterface->renderedImage, SIGNAL(RotationChanged(double)), this,
 			SLOT(slotFlightRotation(double)));
 		connect(mainInterface->renderedImage, SIGNAL(Pause()), this, SLOT(slotRecordPause()));
-		connect(mainInterface->renderedImage, SIGNAL(ShiftModeChanged(bool)), this,
-			SLOT(slotOrthogonalStrafe(bool)));
 
 		// connect system tray
 		connect(

--- a/mandelbulber2/src/interface.cpp
+++ b/mandelbulber2/src/interface.cpp
@@ -343,10 +343,10 @@ void cInterface::ConnectSignals(void)
 		renderedImage, SIGNAL(mouseMoved(int, int)), mainWindow, SLOT(slotMouseMovedOnImage(int, int)));
 	QApplication::connect(renderedImage, SIGNAL(singleClick(int, int, Qt::MouseButton)), mainWindow,
 		SLOT(slotMouseClickOnImage(int, int, Qt::MouseButton)));
-	QApplication::connect(
-		renderedImage, SIGNAL(keyPress(Qt::Key)), mainWindow, SLOT(slotKeyPressOnImage(Qt::Key)));
-	QApplication::connect(
-		renderedImage, SIGNAL(keyRelease(Qt::Key)), mainWindow, SLOT(slotKeyReleaseOnImage(Qt::Key)));
+	QApplication::connect(renderedImage, SIGNAL(keyPress(QKeyEvent *)), mainWindow,
+		SLOT(slotKeyPressOnImage(QKeyEvent *)));
+	QApplication::connect(renderedImage, SIGNAL(keyRelease(QKeyEvent *)), mainWindow,
+		SLOT(slotKeyReleaseOnImage(QKeyEvent *)));
 	QApplication::connect(renderedImage, SIGNAL(mouseWheelRotated(int)), mainWindow,
 		SLOT(slotMouseWheelRotatedOnImage(int)));
 

--- a/mandelbulber2/src/render_window.hpp
+++ b/mandelbulber2/src/render_window.hpp
@@ -151,8 +151,8 @@ private slots:
 	// rendered image widget
 	void slotMouseMovedOnImage(int x, int y);
 	void slotMouseClickOnImage(int x, int y, Qt::MouseButton button);
-	void slotKeyPressOnImage(Qt::Key key);
-	void slotKeyReleaseOnImage(Qt::Key key);
+	void slotKeyPressOnImage(QKeyEvent *event);
+	void slotKeyReleaseOnImage(QKeyEvent *event);
 	void slotMouseWheelRotatedOnImage(int delta);
 
 private:

--- a/mandelbulber2/src/render_window_slots.cpp
+++ b/mandelbulber2/src/render_window_slots.cpp
@@ -134,24 +134,54 @@ void RenderWindow::slotChangedComboMouseClickFunction(int index)
 	}
 }
 
-void RenderWindow::slotKeyPressOnImage(Qt::Key key)
+void RenderWindow::slotKeyPressOnImage(QKeyEvent *event)
 {
 
-	switch (key)
+	int key = event->key();
+	Qt::KeyboardModifiers modifiers = event->modifiers();
+	if (modifiers & Qt::ShiftModifier)
+	{ // Shift pressed
+		switch (key)
+		{
+			case Qt::Key_Up: gMainInterface->RotateCamera("bu_rotate_up"); break;
+			case Qt::Key_Down: gMainInterface->RotateCamera("bu_rotate_down"); break;
+			case Qt::Key_Left: gMainInterface->RotateCamera("bu_rotate_left"); break;
+			case Qt::Key_Right: gMainInterface->RotateCamera("bu_rotate_right"); break;
+			default: break;
+		}
+	}
+	else if (modifiers & Qt::ControlModifier)
+	{ // Ctrl pressed
+		switch (key)
+		{
+			case Qt::Key_Up: gMainInterface->MoveCamera("bu_move_up"); break;
+			case Qt::Key_Down: gMainInterface->MoveCamera("bu_move_down"); break;
+			case Qt::Key_Left: gMainInterface->RotateCamera("bu_rotate_roll_left"); break;
+			case Qt::Key_Right: gMainInterface->RotateCamera("bu_rotate_roll_right"); break;
+			default: break;
+		}
+	}
+	else
 	{
-		case Qt::Key_W: gMainInterface->MoveCamera("bu_move_up"); break;
-		case Qt::Key_S: gMainInterface->MoveCamera("bu_move_down"); break;
-		case Qt::Key_A: gMainInterface->MoveCamera("bu_move_left"); break;
-		case Qt::Key_D: gMainInterface->MoveCamera("bu_move_right"); break;
-		case Qt::Key_Up: gMainInterface->MoveCamera("bu_move_forward"); break;
-		case Qt::Key_Down: gMainInterface->MoveCamera("bu_move_backward"); break;
-		default: break;
+		// No keyboard modifiers
+		switch (key)
+		{
+			case Qt::Key_W: gMainInterface->MoveCamera("bu_move_up"); break;
+			case Qt::Key_S: gMainInterface->MoveCamera("bu_move_down"); break;
+			case Qt::Key_A: gMainInterface->MoveCamera("bu_move_left"); break;
+			case Qt::Key_D: gMainInterface->MoveCamera("bu_move_right"); break;
+			case Qt::Key_Up: gMainInterface->MoveCamera("bu_move_forward"); break;
+			case Qt::Key_Down: gMainInterface->MoveCamera("bu_move_backward"); break;
+			case Qt::Key_Left: gMainInterface->MoveCamera("bu_move_left"); break;
+			case Qt::Key_Right: gMainInterface->MoveCamera("bu_move_right"); break;
+			default: break;
+		}
 	}
 }
 
-void RenderWindow::slotKeyReleaseOnImage(Qt::Key key)
+void RenderWindow::slotKeyReleaseOnImage(QKeyEvent *event)
 {
-	(void)key;
+	(void)event;
 }
 
 void RenderWindow::slotMouseWheelRotatedOnImage(int delta)

--- a/mandelbulber2/src/rendered_image_widget.cpp
+++ b/mandelbulber2/src/rendered_image_widget.cpp
@@ -595,7 +595,7 @@ void RenderedImage::keyPressEvent(QKeyEvent *event)
 		}
 		else
 		{
-			emit keyPress((Qt::Key)event->key());
+			emit keyPress(event);
 		}
 	}
 }
@@ -648,7 +648,7 @@ void RenderedImage::keyReleaseEvent(QKeyEvent *event)
 		}
 		else
 		{
-			emit keyRelease((Qt::Key)event->key());
+			emit keyRelease(event);
 		}
 	}
 }

--- a/mandelbulber2/src/rendered_image_widget.hpp
+++ b/mandelbulber2/src/rendered_image_widget.hpp
@@ -144,8 +144,8 @@ private:
 signals:
 	void mouseMoved(int x, int y);
 	void singleClick(int x, int y, Qt::MouseButton button);
-	void keyPress(Qt::Key key);
-	void keyRelease(Qt::Key key);
+	void keyPress(QKeyEvent *event);
+	void keyRelease(QKeyEvent *event);
 	void mouseWheelRotated(int delta);
 };
 


### PR DESCRIPTION
Hi all
I'm using Mandelbulber for some hours now, and I realized that I missed some keyboard shortcuts to navigate more quickly in 3D world.

Here is a proposal of some shortcuts (have a look to readme.md for description).
I tried them for some time and I'm happy with that. Hope it'll be your case too.
The advantage using arrows than W/S/A/D is that it works the same independently of the keyboard layout (I'm actualy using an AZERTY layout, and W/S/A/D doesn't feel intuitive).

