### PR TITLE
Display double crosshair in render window when stereoscopic SBS mode enabled

### DIFF
--- a/mandelbulber2/src/rendered_image_widget.cpp
+++ b/mandelbulber2/src/rendered_image_widget.cpp
@@ -733,10 +733,23 @@ void RenderedImage::DisplayCrosshair()
 	crossCenter.x = (sw * 0.5) * (1.0 + 2.0 * crossShift.x);
 	crossCenter.y = (sh * 0.5) * (1.0 + 2.0 * crossShift.y);
 
-	image->AntiAliasedLine(
-		crossCenter.x, 0, crossCenter.x, sh, -1, -1, sRGB8(255, 255, 255), sRGBfloat(0.3, 0.3, 0.3), 1);
-	image->AntiAliasedLine(
-		0, crossCenter.y, sw, crossCenter.y, -1, -1, sRGB8(255, 255, 255), sRGBfloat(0.3, 0.3, 0.3), 1);
+	if (params->Get<bool>("stereo_enabled")
+			&& params->Get<bool>("stereo_mode") == cStereo::stereoLeftRight)
+	{
+		image->AntiAliasedLine(crossCenter.x / 2, 0, crossCenter.x / 2, sh, -1, -1,
+			sRGB8(255, 255, 255), sRGBfloat(0.3, 0.3, 0.3), 1);
+		image->AntiAliasedLine(crossCenter.x * 1.5, 0, crossCenter.x * 1.5, sh, -1, -1,
+			sRGB8(255, 255, 255), sRGBfloat(0.3, 0.3, 0.3), 1);
+		image->AntiAliasedLine(0, crossCenter.y, sw, crossCenter.y, -1, -1, sRGB8(255, 255, 255),
+			sRGBfloat(0.3, 0.3, 0.3), 1);
+	}
+	else
+	{
+		image->AntiAliasedLine(crossCenter.x, 0, crossCenter.x, sh, -1, -1, sRGB8(255, 255, 255),
+			sRGBfloat(0.3, 0.3, 0.3), 1);
+		image->AntiAliasedLine(0, crossCenter.y, sw, crossCenter.y, -1, -1, sRGB8(255, 255, 255),
+			sRGBfloat(0.3, 0.3, 0.3), 1);
+	}
 }
 
 void RenderedImage::DrawHud(CVector3 rotation)


### PR DESCRIPTION
Okay, I'm really not sure about the code here. It **seems** to work, but I'm sure there are some cases it doesn't. I didn't find them.
This is a quick'n dirty fix to allow you to see what I needed while exploring fractales in SBS cross eyed mode (the mode I use the more for exploring).
Thanks and sorry about this dirty code ! But, you get the idea.