### PR TITLE
Add const to member functions

### DIFF
--- a/mandelbulber2/src/audio_track_collection.cpp
+++ b/mandelbulber2/src/audio_track_collection.cpp
@@ -121,7 +121,7 @@ cAudioTrack *cAudioTrackCollection::GetAudioTrackPtr(const QString fullParameter
 	}
 }
 
-void cAudioTrackCollection::AddParameters(cParameterContainer *params, const QString parameterName)
+void cAudioTrackCollection::AddParameters(cParameterContainer *params, const QString parameterName) const
 {
 	if (!params->IfExists(FullParameterName("enable", parameterName)))
 	{
@@ -160,7 +160,7 @@ void cAudioTrackCollection::AddParameters(cParameterContainer *params, const QSt
 }
 
 void cAudioTrackCollection::RemoveParameters(
-	cParameterContainer *params, const QString parameterName)
+	cParameterContainer *params, const QString parameterName) const
 {
 	if (params->IfExists(FullParameterName("enable", parameterName)))
 	{
@@ -183,7 +183,7 @@ void cAudioTrackCollection::RemoveParameters(
 }
 
 QString cAudioTrackCollection::FullParameterName(
-	const QString &nameOfSoundParameter, const QString parameterName)
+	const QString &nameOfSoundParameter, const QString parameterName) const
 {
 	return prefix + QString("_") + nameOfSoundParameter + "_" + parameterName;
 }

--- a/mandelbulber2/src/audio_track_collection.h
+++ b/mandelbulber2/src/audio_track_collection.h
@@ -56,9 +56,9 @@ public:
 	void DeleteAudioTrack(const QString fullParameterName, cParameterContainer *params);
 	void DeleteAllAudioTracks(cParameterContainer *params);
 	cAudioTrack *GetAudioTrackPtr(const QString fullParameterName) const;
-	void AddParameters(cParameterContainer *params, const QString parameterName);
-	void RemoveParameters(cParameterContainer *params, const QString parameterName);
-	QString FullParameterName(const QString &nameOfSoundParameter, const QString parameterName);
+	void AddParameters(cParameterContainer *params, const QString parameterName) const;
+	void RemoveParameters(cParameterContainer *params, const QString parameterName) const;
+	QString FullParameterName(const QString &nameOfSoundParameter, const QString parameterName) const;
 	void LoadAllAudioFiles(cParameterContainer *params);
 	void RefreshAllAudioTracks(cParameterContainer *params);
 	void SetPrefix(QString _prefix) { prefix = _prefix; }

--- a/mandelbulber2/src/clew-cl.hpp
+++ b/mandelbulber2/src/clew-cl.hpp
@@ -609,14 +609,14 @@ public:
             return i;
         }
     
-        bool operator==(iterator i)
+        bool operator==(iterator i) const
         {
             return ((vec_ == i.vec_) && 
                     (index_ == i.index_) && 
                     (initialized_ == i.initialized_));
         }
 
-        bool operator!=(iterator i)
+        bool operator!=(iterator i) const
         {
             return (!(*this==i));
         }
@@ -641,7 +641,7 @@ public:
             index_ -= x;
         }
 
-        T operator *()
+        T operator *() const
         {
             return vec_[index_];
         }
@@ -3157,7 +3157,7 @@ public:
 
     KernelFunctor(const KernelFunctor& rhs);
 
-    cl_int getError() { return err_; }
+    cl_int getError() const { return err_; }
 
     inline Event operator()(const VECTOR_CLASS<Event>* events = NULL);
 

--- a/mandelbulber2/src/statistics.h
+++ b/mandelbulber2/src/statistics.h
@@ -59,7 +59,7 @@ public:
 	double GetNumberOfIterationsPerSecond() const { return double(totalNumberOfIterations) / time; }
 	double GetMissedDEPercentage() const { return double(missedDE) / numberOfRaymarchings * 100.0; }
 	QString GetDETypeString() const { return usedDEType; }
-	double GetAverageDOFSamples() { return double(totalNumberOfDOFRepeats) / numberOfRenderedPixels; }
+	double GetAverageDOFSamples() const { return double(totalNumberOfDOFRepeats) / numberOfRenderedPixels; }
 	void Reset();
 };
 


### PR DESCRIPTION
Note that cAudioTrackCollection::{Add,Remove}Parameters can be made
const since the parameters are added/removed to the cParameterContainer
class passed as argument.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
