### PR TITLE
Remove unused variable

### DIFF
--- a/mandelbulber2/src/render_worker.cpp
+++ b/mandelbulber2/src/render_worker.cpp
@@ -803,7 +803,6 @@ cRenderWorker::sRayRecursionOut cRenderWorker::RayRecursion(
 
 				if (rayIndex < reflectionsMax)
 				{
-					enumRayBranch rayBranch = rayStack[rayIndex].rayBranch;
 					if (rayStack[rayIndex].rayBranch == rayBranchReflection)
 					{
 						// qDebug() << "Reflection" << rayIndex;


### PR DESCRIPTION
Fixes compilation warnings for both gcc and clang:

	warning: unused variable 'rayBranch' [-Wunused-variable]

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
