### PR TITLE
Bugfix FilePathHelper

### DIFF
--- a/mandelbulber2/src/files.cpp
+++ b/mandelbulber2/src/files.cpp
@@ -436,14 +436,14 @@ QString FilePathHelper(const QString &path, const QStringList &pathList)
 	// original file was found
 	if (FileExists(path)) return path;
 
-	WriteLogCout("File " + path + " not found. Looking for the file in another locations", 2);
+	WriteLogCout("File " + path + " not found. Looking for the file in another locations\n", 2);
 
 	foreach (QString alternatePath, pathList)
 	{
-		WriteLogCout("Looking for the file at " + path, 2);
-		if (FileExists((path)))
+		WriteLogCout("Looking for the file at " + alternatePath + "\n", 2);
+		if (FileExists((alternatePath)))
 		{
-			WriteLogCout("File found at" + path, 2);
+			WriteLogCout("File found at" + alternatePath + "\n", 2);
 			return alternatePath;
 		}
 	}


### PR DESCRIPTION
If the path was not found, the same path was tried again and again.
Fix this by trying the alternate paths instead.

Add newlines to the printouts to not print all paths on the line.

The changes makes it possible to run the example file

	mandelbulber2/deploy/share/mandelbulber2/examples/Robert Pancoast
	collection - license Creative Commons (CC-BY 4.0)/icoastahedron.fract

even if the repo isn't checked out to D:/GIT/mandelbulber2.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

<!-- Please describe what your pullrequest is changing -->
