### PR TITLE
Fix assert in CastIntToSize

### DIFF
--- a/mandelbulber2/src/cast.hpp
+++ b/mandelbulber2/src/cast.hpp
@@ -49,7 +49,7 @@ inline int CastSizeToInt(size_t sizeValue)
 // Safe Cast Helper for int ==> size_t
 inline size_t CastIntToSize(int intValue)
 {
-	assert(intValue < 0);
+	assert(intValue >= 0);
 	return size_t(unsigned(intValue));
 }
 


### PR DESCRIPTION
Seems it's never used but let's fix it anyway.