### PR TITLE
Mark unused argument

### DIFF
--- a/mandelbulber2/qt/dock_navigation.cpp
+++ b/mandelbulber2/qt/dock_navigation.cpp
@@ -217,5 +217,7 @@ void cDockNavigation::EnableOpenCLModeComboBox(bool enabled) const
 #ifdef USE_OPENCL
 	ui->comboBox_opencl_mode->setVisible(enabled);
 	ui->label_opencl_mode->setVisible(enabled);
+#else
+	Q_UNUSED(enabled);
 #endif
 }


### PR DESCRIPTION
Silences a clang warning:

    ../qt/dock_navigation.cpp:215:53: warning: unused parameter 'enabled' [-Wunused-parameter]
    void cDockNavigation::EnableOpenCLModeComboBox(bool enabled) const
                                                   ^
    1 warning generated.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
