### PR TITLE
Preselect 1st GPU device in preferences when open for the first time

### DIFF
--- a/mandelbulber2/qt/preferences_dialog.cpp
+++ b/mandelbulber2/qt/preferences_dialog.cpp
@@ -465,12 +465,18 @@ void cPreferencesDialog::UpdateOpenCLListBoxes()
 	ui->listWidget_opencl_device_list->clear();
 	QList<QPair<QString, QString>> devices = GetOpenCLDevices();
 	QStringList selectedDevices = gPar->Get<QString>("opencl_device_list").split("|");
+	bool noDeviceSelected = selectedDevices.first().isEmpty();
 	for (auto device : devices)
 	{
 		QListWidgetItem *item = new QListWidgetItem(device.second);
 		item->setData(1, device.first);
 		bool selected = selectedDevices.contains(device.first);
 		ui->listWidget_opencl_device_list->addItem(item);
+		if (noDeviceSelected)
+		{
+			noDeviceSelected = false;
+			selected = true;
+		}
 		item->setSelected(selected);
 	}
 }


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #589
-->

### This pullrequest changes

Preselect 1st GPU device in the preferences when open for the first time, so a GPU device is selected when enabling OpenCL
