### PR TITLE
implemented world normal pass, fixed screenspace normal pass

### DIFF
--- a/mandelbulber2/qt/image_save_dialog.ui
+++ b/mandelbulber2/qt/image_save_dialog.ui
@@ -393,6 +393,39 @@ and will only be present after enabling and re-render.</string>
                 </property>
                </widget>
               </item>
+			  <item row="6" column="0">
+               <widget class="MyCheckBox" name="checkBox_normalWorld_enabled">
+                <property name="text">
+                 <string>World Normal</string>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="1">
+               <widget class="MyComboBox" name="comboBox_normalWorld_quality">
+                <item>
+                 <property name="text">
+                  <string>8 bit</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>16 bit</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>32 bit</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="6" column="2">
+               <widget class="MyLineEdit" name="text_normalWorld_postfix">
+                <property name="text">
+                 <string/>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
            </item>

--- a/mandelbulber2/qt/preferences_dialog.ui
+++ b/mandelbulber2/qt/preferences_dialog.ui
@@ -36,7 +36,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tabGeneral">
       <attribute name="icon">
@@ -57,8 +57,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>588</width>
-            <height>743</height>
+            <width>582</width>
+            <height>741</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_general">
@@ -602,8 +602,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>588</width>
-            <height>743</height>
+            <width>582</width>
+            <height>741</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_image">
@@ -962,6 +962,39 @@ and will only be present after enabling and re-render.</string>
                   </property>
                  </widget>
                 </item>
+                <item row="6" column="0">
+                 <widget class="MyCheckBox" name="checkBox_normalWorld_enabled">
+                  <property name="text">
+                   <string>World Normal</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="1">
+                 <widget class="MyComboBox" name="comboBox_normalWorld_quality">
+                  <item>
+                   <property name="text">
+                    <string>8 bit</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>16 bit</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>32 bit</string>
+                   </property>
+                  </item>
+                 </widget>
+                </item>
+                <item row="6" column="2">
+                 <widget class="MyLineEdit" name="text_normalWorld_postfix">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
                </layout>
               </widget>
              </item>
@@ -1153,8 +1186,8 @@ and will only be present after enabling and re-render.</string>
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>251</width>
-            <height>912</height>
+            <width>565</width>
+            <height>769</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_OpenCL">

--- a/mandelbulber2/src/cimage.cpp
+++ b/mandelbulber2/src/cimage.cpp
@@ -100,6 +100,7 @@ bool cImage::AllocMem()
 				opacityBuffer.resize(width * height);
 				colourBuffer.resize(width * height);
 				normalFloat.resize(width * height);
+				normalFloatWorld.resize(width * height);
 				specularFloat.resize(width * height);
 				diffuseFloat.resize(width * height);
 				worldFloat.resize(width * height);
@@ -166,6 +167,7 @@ void cImage::ClearImage()
 	std::fill(colourBuffer.begin(), colourBuffer.end(), sRGB8());
 
 	if (opt.optionalNormal) std::fill(normalFloat.begin(), normalFloat.end(), sRGBFloat());
+	if (opt.optionalNormalWorld) std::fill(normalFloatWorld.begin(), normalFloatWorld.end(), sRGBFloat());
 	if (opt.optionalSpecular) std::fill(specularFloat.begin(), specularFloat.end(), sRGBFloat());
 	if (opt.optionalDiffuse) std::fill(diffuseFloat.begin(), diffuseFloat.end(), sRGBFloat());
 	if (opt.optionalWorld) std::fill(worldFloat.begin(), worldFloat.end(), sRGBFloat());
@@ -197,6 +199,7 @@ void cImage::FreeImage()
 	zBuffer.clear();
 
 	normalFloat.clear();
+	normalFloatWorld.clear();
 	specularFloat.clear();
 	diffuseFloat.clear();
 	worldFloat.clear();
@@ -331,6 +334,7 @@ int cImage::GetUsedMB() const
 
 	quint64 optionalChannels = 0;
 	if (opt.optionalNormal) optionalChannels++;
+	if (opt.optionalNormalWorld) optionalChannels++;
 	if (opt.optionalSpecular) optionalChannels++;
 	if (opt.optionalDiffuse) optionalChannels++;
 	if (opt.optionalWorld) optionalChannels++;
@@ -1099,6 +1103,11 @@ void cImage::GetStereoLeftRightImages(cImage *left, cImage *right)
 				{
 					left->normalFloat[ptrNew] = normalFloat[ptrLeft];
 					right->normalFloat[ptrNew] = normalFloat[ptrRight];
+				}
+				if (opt.optionalNormalWorld)
+				{
+					left->normalFloatWorld[ptrNew] = normalFloatWorld[ptrLeft];
+					right->normalFloatWorld[ptrNew] = normalFloatWorld[ptrRight];
 				}
 				if (opt.optionalSpecular)
 				{

--- a/mandelbulber2/src/cimage.hpp
+++ b/mandelbulber2/src/cimage.hpp
@@ -51,10 +51,11 @@ struct sImageOptional
 	inline bool operator==(sImageOptional other) const
 	{
 		return other.optionalNormal == optionalNormal && other.optionalSpecular == optionalSpecular
-					 && other.optionalDiffuse == optionalDiffuse && other.optionalWorld == optionalWorld;
+					 && other.optionalDiffuse == optionalDiffuse && other.optionalWorld == optionalWorld && other.optionalNormalWorld;
 	}
 
 	bool optionalNormal{false};
+	bool optionalNormalWorld{false};
 	bool optionalSpecular{false};
 	bool optionalDiffuse{false};
 	bool optionalWorld{false};
@@ -66,6 +67,7 @@ struct sAllImageData
 	quint16 alphaBuffer;
 	quint16 opacityBuffer;
 	sRGBFloat normalFloat;
+	sRGBFloat normalFloatWorld;
 	sRGBFloat normalSpecular;
 	sRGBFloat worldPosition;
 	sRGB8 colourBuffer;
@@ -145,6 +147,10 @@ public:
 	{
 		normalFloat[getImageIndex(x, y)] = pixel;
 	}
+	inline void PutPixelNormalWorld(quint64 x, quint64 y, sRGBFloat pixel)
+	{
+		normalFloatWorld[getImageIndex(x, y)] = pixel;
+	}
 	inline void PutPixelSpecular(quint64 x, quint64 y, sRGBFloat pixel)
 	{
 		specularFloat[getImageIndex(x, y)] = pixel;
@@ -187,6 +193,10 @@ public:
 	inline sRGBFloat GetPixelNormal(quint64 x, quint64 y)
 	{
 		return GetPixelGeneric(normalFloat, opt.optionalNormal, x, y);
+	}
+	inline sRGBFloat GetPixelNormalWorld(quint64 x, quint64 y)
+	{
+		return GetPixelGeneric(normalFloatWorld, opt.optionalNormalWorld, x, y);
 	}
 	inline sRGBFloat GetPixelSpecular(quint64 x, quint64 y)
 	{
@@ -332,6 +342,7 @@ private:
 
 	// optional image buffers
 	std::vector<sRGBFloat> normalFloat;
+	std::vector<sRGBFloat> normalFloatWorld;
 	std::vector<sRGBFloat> specularFloat;
 	std::vector<sRGBFloat> diffuseFloat;
 	std::vector<sRGBFloat> worldFloat;

--- a/mandelbulber2/src/file_image.cpp
+++ b/mandelbulber2/src/file_image.cpp
@@ -101,6 +101,7 @@ QString ImageFileSave::ImageChannelName(enumImageContentType imageContentType)
 		case IMAGE_CONTENT_ALPHA: return "alpha";
 		case IMAGE_CONTENT_ZBUFFER: return "zbuffer";
 		case IMAGE_CONTENT_NORMAL: return "normal";
+		case IMAGE_CONTENT_NORMAL_WORLD: return "normalWorld";
 		case IMAGE_CONTENT_SPECULAR: return "specular";
 		case IMAGE_CONTENT_DIFFUSE: return "diffuse";
 		case IMAGE_CONTENT_WORLD_POSITION: return "world";
@@ -110,7 +111,7 @@ QString ImageFileSave::ImageChannelName(enumImageContentType imageContentType)
 
 QStringList ImageFileSave::ImageChannelNames()
 {
-	return QStringList({"color", "alpha", "zbuffer", "normal", "specular", "diffuse", "world"});
+	return QStringList({"color", "alpha", "zbuffer", "normal", "specular", "diffuse", "world", "normalWorld"});
 }
 
 ImageFileSave::enumImageFileType ImageFileSave::ImageFileType(QString imageFileExtension)
@@ -252,6 +253,7 @@ QStringList ImageFileSavePNG::SaveImage()
 			}
 			case IMAGE_CONTENT_ZBUFFER:
 			case IMAGE_CONTENT_NORMAL:
+			case IMAGE_CONTENT_NORMAL_WORLD:
 			case IMAGE_CONTENT_SPECULAR:
 			case IMAGE_CONTENT_DIFFUSE:
 			case IMAGE_CONTENT_WORLD_POSITION:
@@ -333,6 +335,7 @@ QStringList ImageFileSaveJPG::SaveImage()
 				break;
 			}
 			case IMAGE_CONTENT_NORMAL:
+			case IMAGE_CONTENT_NORMAL_WORLD:
 			case IMAGE_CONTENT_SPECULAR:
 			case IMAGE_CONTENT_DIFFUSE:
 			case IMAGE_CONTENT_WORLD_POSITION:
@@ -382,6 +385,7 @@ QStringList ImageFileSaveTIFF::SaveImage()
 				break;
 			case IMAGE_CONTENT_ZBUFFER:
 			case IMAGE_CONTENT_NORMAL:
+			case IMAGE_CONTENT_NORMAL_WORLD:
 			case IMAGE_CONTENT_SPECULAR:
 			case IMAGE_CONTENT_DIFFUSE:
 			case IMAGE_CONTENT_WORLD_POSITION:
@@ -469,6 +473,7 @@ void ImageFileSavePNG::SavePNG(
 			case IMAGE_CONTENT_ALPHA:
 			case IMAGE_CONTENT_ZBUFFER: colorType = PNG_COLOR_TYPE_GRAY; break;
 			case IMAGE_CONTENT_NORMAL: colorType = PNG_COLOR_TYPE_RGB; break;
+			case IMAGE_CONTENT_NORMAL_WORLD: colorType = PNG_COLOR_TYPE_RGB; break;
 			case IMAGE_CONTENT_SPECULAR: colorType = PNG_COLOR_TYPE_RGB; break;
 			case IMAGE_CONTENT_DIFFUSE: colorType = PNG_COLOR_TYPE_RGB; break;
 			case IMAGE_CONTENT_WORLD_POSITION: colorType = PNG_COLOR_TYPE_RGB; break;
@@ -494,6 +499,7 @@ void ImageFileSavePNG::SavePNG(
 			case IMAGE_CONTENT_ALPHA: pixelSize *= 1; break;
 			case IMAGE_CONTENT_ZBUFFER: pixelSize *= 1; break;
 			case IMAGE_CONTENT_NORMAL: pixelSize *= 3; break;
+			case IMAGE_CONTENT_NORMAL_WORLD: pixelSize *= 3; break;
 			case IMAGE_CONTENT_SPECULAR: pixelSize *= 3; break;
 			case IMAGE_CONTENT_DIFFUSE: pixelSize *= 3; break;
 			case IMAGE_CONTENT_WORLD_POSITION: pixelSize *= 3; break;
@@ -534,6 +540,7 @@ void ImageFileSavePNG::SavePNG(
 				break;
 				case IMAGE_CONTENT_ZBUFFER:
 				case IMAGE_CONTENT_NORMAL:
+				case IMAGE_CONTENT_NORMAL_WORLD:
 				case IMAGE_CONTENT_SPECULAR:
 				case IMAGE_CONTENT_DIFFUSE:
 				case IMAGE_CONTENT_WORLD_POSITION:
@@ -629,6 +636,9 @@ void ImageFileSavePNG::SavePNG(
 						break;
 						case IMAGE_CONTENT_NORMAL:
 							SavePngRgbPixel(imageChannel, &colorPtr[ptr], image->GetPixelNormal(x, y));
+							break;
+						case IMAGE_CONTENT_NORMAL_WORLD:
+							SavePngRgbPixel(imageChannel, &colorPtr[ptr], image->GetPixelNormalWorld(x, y));
 							break;
 						case IMAGE_CONTENT_SPECULAR:
 							SavePngRgbPixel(imageChannel, &colorPtr[ptr], image->GetPixelSpecular(x, y));
@@ -969,6 +979,7 @@ bool ImageFileSaveJPG::SaveJPEGQt32(QString filename, structSaveImageChannel ima
 			switch (imageChannel.contentType)
 			{
 				case IMAGE_CONTENT_NORMAL: pixel = image->GetPixelNormal(x, y); break;
+				case IMAGE_CONTENT_NORMAL_WORLD: pixel = image->GetPixelNormalWorld(x, y); break;
 				case IMAGE_CONTENT_SPECULAR: pixel = image->GetPixelSpecular(x, y); break;
 				case IMAGE_CONTENT_DIFFUSE: pixel = image->GetPixelDiffuse(x, y); break;
 				case IMAGE_CONTENT_WORLD_POSITION: pixel = image->GetPixelWorld(x, y); break;
@@ -1212,6 +1223,12 @@ void ImageFileSaveEXR::SaveEXR(
 			&frameBuffer, width, height);
 	}
 
+	if (imageConfig.contains(IMAGE_CONTENT_NORMAL_WORLD))
+	{
+		SaveExrRgbChannel(QStringList{"nW.X", "nW.Y", "nW.Z"}, imageConfig[IMAGE_CONTENT_NORMAL_WORLD], &header,
+			&frameBuffer, width, height);
+	}
+
 	if (imageConfig.contains(IMAGE_CONTENT_SPECULAR))
 	{
 		SaveExrRgbChannel(QStringList{"s.X", "s.Y", "s.Z"}, imageConfig[IMAGE_CONTENT_SPECULAR],
@@ -1280,6 +1297,7 @@ void ImageFileSaveEXR::SaveExrRgbChannel(QStringList names, structSaveImageChann
 			switch (imageChannel.contentType)
 			{
 				case IMAGE_CONTENT_NORMAL: pixel = image->GetPixelNormal(x, y); break;
+				case IMAGE_CONTENT_NORMAL_WORLD: pixel = image->GetPixelNormalWorld(x, y); break;
 				case IMAGE_CONTENT_SPECULAR: pixel = image->GetPixelSpecular(x, y); break;
 				case IMAGE_CONTENT_DIFFUSE: pixel = image->GetPixelDiffuse(x, y); break;
 				case IMAGE_CONTENT_WORLD_POSITION: pixel = image->GetPixelWorld(x, y); break;
@@ -1352,6 +1370,7 @@ bool ImageFileSaveTIFF::SaveTIFF(
 		case IMAGE_CONTENT_ALPHA:
 		case IMAGE_CONTENT_ZBUFFER: colorType = PHOTOMETRIC_MINISBLACK; break;
 		case IMAGE_CONTENT_NORMAL: colorType = PHOTOMETRIC_RGB; break;
+		case IMAGE_CONTENT_NORMAL_WORLD: colorType = PHOTOMETRIC_RGB; break;
 		case IMAGE_CONTENT_SPECULAR: colorType = PHOTOMETRIC_RGB; break;
 		case IMAGE_CONTENT_DIFFUSE: colorType = PHOTOMETRIC_RGB; break;
 		case IMAGE_CONTENT_WORLD_POSITION: colorType = PHOTOMETRIC_RGB; break;
@@ -1365,6 +1384,7 @@ bool ImageFileSaveTIFF::SaveTIFF(
 		case IMAGE_CONTENT_ALPHA: samplesPerPixel = 1; break;
 		case IMAGE_CONTENT_ZBUFFER: samplesPerPixel = 1; break;
 		case IMAGE_CONTENT_NORMAL: samplesPerPixel = 3; break;
+		case IMAGE_CONTENT_NORMAL_WORLD: samplesPerPixel = 3; break;
 		case IMAGE_CONTENT_SPECULAR: samplesPerPixel = 3; break;
 		case IMAGE_CONTENT_DIFFUSE: samplesPerPixel = 3; break;
 		case IMAGE_CONTENT_WORLD_POSITION: samplesPerPixel = 3; break;
@@ -1515,6 +1535,9 @@ bool ImageFileSaveTIFF::SaveTIFF(
 				break;
 				case IMAGE_CONTENT_NORMAL:
 					SaveTiffRgbPixel(imageChannel, &colorPtr[ptr], image->GetPixelNormal(x, y));
+					break;
+				case IMAGE_CONTENT_NORMAL_WORLD:
+					SaveTiffRgbPixel(imageChannel, &colorPtr[ptr], image->GetPixelNormalWorld(x, y));
 					break;
 				case IMAGE_CONTENT_SPECULAR:
 					SaveTiffRgbPixel(imageChannel, &colorPtr[ptr], image->GetPixelSpecular(x, y));

--- a/mandelbulber2/src/file_image.hpp
+++ b/mandelbulber2/src/file_image.hpp
@@ -104,6 +104,8 @@ public:
 		IMAGE_CONTENT_DIFFUSE = 5,
 
 		IMAGE_CONTENT_WORLD_POSITION = 6,
+
+		IMAGE_CONTENT_NORMAL_WORLD = 7
 	};
 
 	enum enumImageChannelQualityType

--- a/mandelbulber2/src/initparameters.cpp
+++ b/mandelbulber2/src/initparameters.cpp
@@ -523,6 +523,7 @@ void InitParams(cParameterContainer *par)
 	par->addParam("alpha_enabled", false, morphNone, paramApp);
 	par->addParam("zbuffer_enabled", false, morphNone, paramApp);
 	par->addParam("normal_enabled", false, morphNone, paramApp);
+	par->addParam("normalWorld_enabled", false, morphNone, paramApp);
 	par->addParam("specular_enabled", false, morphNone, paramApp);
 	par->addParam("diffuse_enabled", false, morphNone, paramApp);
 	par->addParam("world_enabled", false, morphNone, paramApp);
@@ -534,6 +535,8 @@ void InitParams(cParameterContainer *par)
 	par->addParam(
 		"normal_quality", int(ImageFileSave::IMAGE_CHANNEL_QUALITY_32), morphNone, paramApp);
 	par->addParam(
+		"normalWorld_quality", int(ImageFileSave::IMAGE_CHANNEL_QUALITY_32), morphNone, paramApp);
+	par->addParam(
 		"specular_quality", int(ImageFileSave::IMAGE_CHANNEL_QUALITY_32), morphNone, paramApp);
 	par->addParam(
 		"diffuse_quality", int(ImageFileSave::IMAGE_CHANNEL_QUALITY_32), morphNone, paramApp);
@@ -543,6 +546,7 @@ void InitParams(cParameterContainer *par)
 	par->addParam("alpha_postfix", QString("_alpha"), morphNone, paramApp);
 	par->addParam("zbuffer_postfix", QString("_zbuffer"), morphNone, paramApp);
 	par->addParam("normal_postfix", QString("_normal"), morphNone, paramApp);
+	par->addParam("normalWorld_postfix", QString("_normalWorld"), morphNone, paramApp);
 	par->addParam("specular_postfix", QString("_specular"), morphNone, paramApp);
 	par->addParam("diffuse_postfix", QString("_diffuse"), morphNone, paramApp);
 	par->addParam("world_postfix", QString("_world"), morphNone, paramApp);

--- a/mandelbulber2/src/netrender_server.hpp
+++ b/mandelbulber2/src/netrender_server.hpp
@@ -132,7 +132,7 @@ private:
 
 public:
 	const QStringList listOfAppSettingToTransfer = {"opencl_mode", "color_enabled", "alpha_enabled",
-		"zbuffer_enabled", "normal_enabled", "specular_enabled", "diffuse_enabled", "world_enabled",
+		"zbuffer_enabled", "normal_enabled", "normalWorld_enabled", "specular_enabled", "diffuse_enabled", "world_enabled",
 		"color_quality", "alpha_quality", "zbuffer_quality", "normal_postfix", "specular_postfix",
 		"diffuse_postfix", "world_postfix", "append_alpha_png", "linear_colorspace", "jpeg_quality",
 		"stereoscopic_in_separate_files", "optional_image_channels_enabled",

--- a/mandelbulber2/src/render_image.cpp
+++ b/mandelbulber2/src/render_image.cpp
@@ -564,6 +564,8 @@ void cRenderer::CreateLineData(int y, QByteArray *lineData) const
 			lineOfImage[x].opacityBuffer = image->GetPixelOpacity(x, y);
 			if (image->GetImageOptional()->optionalNormal)
 				lineOfImage[x].normalFloat = image->GetPixelNormal(x, y);
+			if (image->GetImageOptional()->optionalNormalWorld)
+				lineOfImage[x].normalFloat = image->GetPixelNormalWorld(x, y);
 			if (image->GetImageOptional()->optionalSpecular)
 				lineOfImage[x].normalSpecular = image->GetPixelSpecular(x, y);
 			if (image->GetImageOptional()->optionalWorld)
@@ -596,6 +598,8 @@ void cRenderer::NewLinesArrived(QList<int> lineNumbers, QList<QByteArray> lines)
 				image->PutPixelOpacity(x, y, lineOfImage[x].opacityBuffer);
 				if (image->GetImageOptional()->optionalNormal)
 					image->PutPixelNormal(x, y, lineOfImage[x].normalFloat);
+				if (image->GetImageOptional()->optionalNormalWorld)
+					image->PutPixelNormalWorld(x, y, lineOfImage[x].normalFloatWorld);
 				if (image->GetImageOptional()->optionalSpecular)
 					image->PutPixelSpecular(x, y, lineOfImage[x].normalSpecular);
 				if (image->GetImageOptional()->optionalWorld)

--- a/mandelbulber2/src/render_job.cpp
+++ b/mandelbulber2/src/render_job.cpp
@@ -149,6 +149,7 @@ bool cRenderJob::Init(enumMode _mode, const cRenderingConfiguration &config)
 
 	sImageOptional imageOptional;
 	imageOptional.optionalNormal = paramsContainer->Get<bool>("normal_enabled");
+	imageOptional.optionalNormalWorld = paramsContainer->Get<bool>("normalWorld_enabled");
 	imageOptional.optionalSpecular = paramsContainer->Get<bool>("specular_enabled");
 	imageOptional.optionalWorld = paramsContainer->Get<bool>("world_enabled");
 	imageOptional.optionalDiffuse = paramsContainer->Get<bool>("diffuse_enabled");

--- a/mandelbulber2/src/render_worker.cpp
+++ b/mandelbulber2/src/render_worker.cpp
@@ -186,6 +186,7 @@ void cRenderWorker::doWork()
 			unsigned short alpha = 65535;
 			unsigned short opacity16 = 65535;
 			sRGBFloat normalFloat;
+			sRGBFloat normalFloatWorld;
 			sRGBFloat specularFloat;
 			double depth = 1e20;
 			sRGBFloat worldPositionRGB;
@@ -386,8 +387,18 @@ void cRenderWorker::doWork()
 					CVector3 normalRotated = mRotInv.RotateVector(normal);
 					normalRotated.Normalize();
 					normalFloat.R = (1.0 + normalRotated.x) / 2.0;
-					normalFloat.G = (1.0 + normalRotated.z) / 2.0;
-					normalFloat.B = 1.0 - normalRotated.y;
+					normalFloat.G = (1.0 + normalRotated.y) / 2.0;
+					normalFloat.B = (1.0 + normalRotated.z) / 2.0; // <-- changed this so it corresponds to World Position and World Normal pass. Also normalized B component.
+					//normalFloat.B = 1.0 - normalRotated.y;  // <-- old
+				}
+
+				if (image->GetImageOptional()->optionalNormalWorld)
+				{
+					CVector3 normalNormalized = normal;
+					normalNormalized.Normalize();
+					normalFloatWorld.R = normalNormalized.x;
+					normalFloatWorld.G = normalNormalized.y;
+					normalFloatWorld.B = normalNormalized.z;
 				}
 
 				finalPixelDOF.R += finalPixel.R;
@@ -459,6 +470,8 @@ void cRenderWorker::doWork()
 							image->PutPixelOpacity(xxx, yyy, opacity16);
 							if (image->GetImageOptional()->optionalNormal)
 								image->PutPixelNormal(xxx, yyy, normalFloat);
+							if (image->GetImageOptional()->optionalNormalWorld)
+								image->PutPixelNormalWorld(xxx, yyy, normalFloatWorld);
 							if (image->GetImageOptional()->optionalSpecular)
 								image->PutPixelSpecular(xxx, yyy, specularFloat);
 							if (image->GetImageOptional()->optionalWorld)

--- a/mandelbulber2/src/render_worker.cpp
+++ b/mandelbulber2/src/render_worker.cpp
@@ -387,8 +387,8 @@ void cRenderWorker::doWork()
 					CVector3 normalRotated = mRotInv.RotateVector(normal);
 					normalRotated.Normalize();
 					normalFloat.R = (1.0 + normalRotated.x) / 2.0;
-					normalFloat.G = (1.0 + normalRotated.y) / 2.0;
-					normalFloat.B = (1.0 + normalRotated.z) / 2.0; // <-- changed this so it corresponds to World Position and World Normal pass. Also normalized B component.
+					normalFloat.G = (1.0 + normalRotated.z) / 2.0;
+					normalFloat.B = (1.0 + normalRotated.y) / 2.0; // <-- Also normalized B component.
 					//normalFloat.B = 1.0 - normalRotated.y;  // <-- old
 				}
 


### PR DESCRIPTION
hey,
so finally managed to implement the world normal pass with the help of my colleague.
https://github.com/buddhi1980/mandelbulber2/issues/576

also fixed a small cosometic change with the existing screenscace normal pass, as I suggested here: https://github.com/buddhi1980/mandelbulber2/issues/576#issuecomment-501719851.

only implemented for CPU, guess OpenCL would unfortantely be a bit too tricky for us.

build and tested in Windows with MSCV 2017
would be awesome if you could merge that
thx