### PR TITLE
Add metainfo for mandelbulber.

### DIFF
--- a/mandelbulber2/deploy/linux/com.github.buddhi1980.mandelbulber2.metainfo.xml
+++ b/mandelbulber2/deploy/linux/com.github.buddhi1980.mandelbulber2.metainfo.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+    <id>com.github.buddhi1980.mandelbulber2</id>
+    <launchable type="desktop-id">mandelbulber2.desktop</launchable>
+    <name>Mandelbulber2</name>
+    <summary>Free and open source 3D fractals generator</summary>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>GPL-3.0</project_license>
+    <description>
+        <p>
+            Mandelbulber2 creatively generates three-dimensional fractals.
+            Explore trigonometric, hyper-complex, Mandelbox, IFS, and many other 3D fractals.
+            Render with a great palette of customizable materials to create stunning images and videos.
+        </p>
+
+        <p>
+            Features:
+            High-Performance computing with multiple graphics accelerator cards (multi-GPU support via OpenCL)
+            Mathematical Models and Monte Carlo Algorithms for photo-realistic scenes
+            Enlightening Documentation
+            Renders trigonometric, hyper-complex, Mandelbox, IFS, and many other 3D fractals
+            Complex 3D raymarching: hard shadows, ambient occlusion, depth of field, translucency and refraction, etc.
+            Rich GUI in Qt 5 environment
+            Unlimited image resolution on 64-bit systems
+            Program developed for ARM (experimental), x86 and x64 CPUs (Linux, Windows, macOS)
+            Simple 3D navigator
+            Distributed Network Rendering
+            Key-frame animation for all parameters with different interpolations
+            Material management
+            Texture mapping (color, luminosity, diffusion, normal maps, displacement)
+            Exporting of 3D objects
+            Rendering queue
+            Command line interface for headless systems
+        </p>
+    </description>
+    <url type="homepage">https://mandelbulber.com/</url>
+    <url type="help">https://fractalforums.org/mandelbulber/14</url>
+    <url type="bugtracker">https://github.com/buddhi1980/mandelbulber2/issues</url>
+    <screenshots>
+        <screenshot type="default">
+            <image>https://cloud.githubusercontent.com/assets/11696990/13788910/173cf11a-eae2-11e5-884e-f1d03924a5f3.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://user-images.githubusercontent.com/11696990/52135525-4c3ad100-2646-11e9-920b-770747cb90c0.png</image>
+        </screenshot>
+        <screenshot>
+            <image>https://raw.githubusercontent.com/buddhi1980/mandelbulber2/wiki/assets/images/mandelbulberTestrender.jpg</image>
+        </screenshot>
+    </screenshots>
+    <content_rating type="oars-1.1"/>
+    <releases>
+        <release version="2.25" date="2021-04-21">
+            <description>
+                <p>New features:</p>
+                <ul>
+                    <li>Added new fractal formulas</li>
+                    <li>New subsystem for light sources</li>
+                </ul>
+                <p>Enhancements:</p>
+                <ul>
+                    <li>Modified fractal formulas</li>
+                    <li>Many bug fixes</li>
+                </ul>
+            </description>
+        </release>
+        <release version="2.24" date="2020-12-14">
+            <description>
+                <p>New features:</p>
+                <ul>
+                    <li>Added new fractal formulas</li>
+                    <li>UI improvements</li>
+                </ul>
+                <p>Enhancements:</p>
+                <ul>
+                    <li>Modified fractal formulas</li>
+                    <li>Updated User Manual</li>
+                    <li>Many bug fixes</li>
+                </ul>
+            </description>
+        </release>
+  </releases>
+</component> 

--- a/mandelbulber2/deploy/linux/com.github.buddhi1980.mandelbulber2.metainfo.xml
+++ b/mandelbulber2/deploy/linux/com.github.buddhi1980.mandelbulber2.metainfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
     <id>com.github.buddhi1980.mandelbulber2</id>
-    <launchable type="desktop-id">mandelbulber2.desktop</launchable>
+    <launchable type="desktop-id">com.github.buddhi1980.mandelbulber2.desktop</launchable>
     <name>Mandelbulber2</name>
     <summary>Free and open source 3D fractals generator</summary>
     <metadata_license>CC0-1.0</metadata_license>
@@ -15,22 +15,22 @@
 
         <p>
             Features:
-            High-Performance computing with multiple graphics accelerator cards (multi-GPU support via OpenCL)
-            Mathematical Models and Monte Carlo Algorithms for photo-realistic scenes
-            Enlightening Documentation
-            Renders trigonometric, hyper-complex, Mandelbox, IFS, and many other 3D fractals
-            Complex 3D raymarching: hard shadows, ambient occlusion, depth of field, translucency and refraction, etc.
-            Rich GUI in Qt 5 environment
-            Unlimited image resolution on 64-bit systems
-            Program developed for ARM (experimental), x86 and x64 CPUs (Linux, Windows, macOS)
-            Simple 3D navigator
-            Distributed Network Rendering
-            Key-frame animation for all parameters with different interpolations
-            Material management
-            Texture mapping (color, luminosity, diffusion, normal maps, displacement)
-            Exporting of 3D objects
-            Rendering queue
-            Command line interface for headless systems
+            <li>High-Performance computing with multiple graphics accelerator cards (multi-GPU support via OpenCL)</li>
+            <li>Mathematical Models and Monte Carlo Algorithms for photo-realistic scenes</li>
+            <li>Enlightening Documentation</li>
+            <li>Renders trigonometric, hyper-complex, Mandelbox, IFS, and many other 3D fractals</li>
+            <li>Complex 3D raymarching: hard shadows, ambient occlusion, depth of field, translucency and refraction, etc.</li>
+            <li>Rich GUI in Qt 5 environment</li>
+            <li>Unlimited image resolution on 64-bit systems</li>
+            <li>Program developed for ARM (experimental), x86 and x64 CPUs (Linux, Windows, macOS)</li>
+            <li>Simple 3D navigator</li>
+            <li>Distributed Network Rendering</li>
+            <li>Key-frame animation for all parameters with different interpolations</li>
+            <li>Material management</li>
+            <li>Texture mapping (color, luminosity, diffusion, normal maps, displacement)</li>
+            <li>Exporting of 3D objects</li>
+            <li>Rendering queue</li>
+            <li>Command line interface for headless systems</li>
         </p>
     </description>
     <url type="homepage">https://mandelbulber.com/</url>


### PR DESCRIPTION
Add metainfo for mandelbulber.
This is a metadata of an app, useful when it is package and display in some kind of app store like Flathub.

https://flathub.org/apps/details/com.github.buddhi1980.mandelbulber2

Also, are you interest to be the co-owner of Flathub repo of Mandelbulber?
https://github.com/flathub/com.github.buddhi1980.mandelbulber2