### PR TITLE
Fix Docker build (#857)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,17 +55,17 @@ ENV MANDELBULBER=/usr/sbin/mandelbulber2 \
     USER_NAME=mandelbulber \
     USER_HOME=/home/mandelbulber
 
-COPY --from=builder /home/builder/src/*.pkg.tar.xz /tmp/
-RUN pacman -U /tmp/*.pkg.tar.xz  --noconfirm --noprogressbar && \
-    rm -f /tmp/*.pkg.tar.xz
+COPY --from=builder /home/builder/src/*.pkg.tar.zst /tmp/
+RUN pacman -U /tmp/*.pkg.tar.zst  --noconfirm --noprogressbar && \
+    rm -f /tmp/*.pkg.tar.zst
 
-RUN useradd -m ${USER_NAME}
+RUN useradd -m ${USER_NAME} -u ${USER_UID}
 
 RUN mkdir -p /usr/share/doc/mandelbulber2
 RUN chown "${USER_UID}:0" "${USER_HOME}" && \
     chmod ug+rwx "${USER_HOME}"
 
-USER ${USER_UID}
+USER ${USER_NAME}
 WORKDIR ${USER_HOME}
 #ENTRYPOINT ["/usr/local/bin/entrypoint"]
 #CMD ["--version"]


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

Resolves #857

### This pullrequest changes

This PR has the following changes in the Dockerfile.

- container user now has name `mandelbulber` and can run `mandelbulber2` from $(id).
- Change to filetype in COPY step so it can successfuly resolve archive from previous stage.

<!-- Please describe what your pullrequest is changing -->
<!-- If you are adding an example, make sure it only refers to files in
     $SHARED_DIR, which are the files under
     mandelbulber2/deploy/share/mandelbulber2, see
     mandelbulber2/deploy/share/mandelbulber2/data/mandelbulber_1.21_defaults.fract
     for an example (e.g. file_background)