### PR TITLE
qmake: fix build when ms-gsl is installed

### DIFF
--- a/mandelbulber2/qmake/common.pri
+++ b/mandelbulber2/qmake/common.pri
@@ -119,10 +119,6 @@ macx:m1:QMAKE_CXXFLAGS += -ffast-math -Xpreprocessor
 
 macx:DEFINES += "SHARED_DIR_IS_APP_DIR" 
 
-# test hardcoded lib path for gsl in travis container 
-#QMAKE_CXXFLAGS += -I/usr/include/gsl
-
-QMAKE_CXXFLAGS += -I/usr/include/gsl
 m1:QMAKE_CXXFLAGS += -I/opt/homebrew/include
 
 # library linking


### PR DESCRIPTION
By injecting -I/usr/include/gsl, `#include <algorithm>` starts to mean "use ms-gsl's algorithm" rather than the C++ stdlib one. But all of the includes for ms-gsl here are properly namespaced, e.g. <gsl/foo.h>, so we can drop the explicit -I*.

Bug: https://bugs.gentoo.org/834692

