### PR TITLE
Fix null-pointer crash in headless keyframe render

### DIFF
--- a/mandelbulber2/src/animation_keyframes.cpp
+++ b/mandelbulber2/src/animation_keyframes.cpp
@@ -371,19 +371,27 @@ bool cKeyframeAnimation::slotRenderKeyframes()
 		mainInterface->SynchronizeInterface(params, fractalParams, qInterface::read);
 	}
 
+	// In headless (--nogui) mode mainInterface->mainWindow is null. The
+	// original code unconditionally dereferenced it inside the error
+	// branches below, crashing the whole CLI render. Guard the parent
+	// widget so headless runs report errors to stderr instead.
+	QWidget *errParent = mainInterface->mainWindow
+		? mainInterface->mainWindow->GetCentralWidget()
+		: nullptr;
+
 	if (keyframes)
 	{
 		if (keyframes->GetNumberOfFrames() == 0)
 		{
 			emit showErrorMessage(QObject::tr("No frames to render"), cErrorMessage::errorMessage,
-				mainInterface->mainWindow->GetCentralWidget());
+				errParent);
 		}
 		else if (!QDir(params->Get<QString>("anim_keyframe_dir")).exists())
 		{
 			emit showErrorMessage(
 				QObject::tr("The folder %1 does not exist. Please specify a valid location.")
 					.arg(params->Get<QString>("anim_keyframe_dir")),
-				cErrorMessage::errorMessage, mainInterface->mainWindow->GetCentralWidget());
+				cErrorMessage::errorMessage, errParent);
 		}
 		else
 		{


### PR DESCRIPTION
### Problem

`--nogui --keyframe` segfaults unconditionally on any preset (including the bundled `examples/keyframe_anim_mandelbulb.fract` and `keyframe_anim_mandelbox_boxes.fract`) before any frame is rendered. Kernel log:

```
mandelbulber2[3196]: segfault at 30 ip ... error 4 in mandelbulber2[...]
```

(The `0x30` offset is a null-deref on a Qt widget.)

### Cause

`cKeyframeAnimation::slotRenderKeyframes()` dereferences `mainInterface->mainWindow->GetCentralWidget()` in both error branches (no-frames, missing-anim-dir). Under `cHeadless::RenderKeyframeAnimation` the `mainWindow` pointer is null, so the error path crashes the process before the user sees why the render failed.

gdb backtrace at the crash:

```
#0 RenderWindow::GetCentralWidget() const
#1 cKeyframeAnimation::slotRenderKeyframes()
#2 cHeadless::RenderKeyframeAnimation()
#3 main
```

### Fix

Cache the widget pointer once at the top of `slotRenderKeyframes`, null-checking `mainInterface->mainWindow`. `cErrorMessage::showMessage` already accepts a null parent for stderr output, so no further changes are needed.

### Testing

Tested on Pop!_OS 24.04 / Qt 5.15.13, master at `b4b420a`, with three keyframe presets:

- `examples/keyframe_anim_mandelbulb.fract` — rendered cleanly
- `examples/keyframe_anim_mandelbox_boxes.fract` — rendered cleanly
- Custom 20-keyframe preset with a misconfigured `anim_keyframe_dir` — reports "The folder ... does not exist" and exits cleanly instead of segfaulting

GUI keyframe rendering still works normally; the guard only changes behaviour when `mainWindow` is null.