### PR TITLE
Changed char to uchar in full_engine, fixing invalid assignments

### DIFF
--- a/mandelbulber2/opencl/engines/full_engine.cl
+++ b/mandelbulber2/opencl/engines/full_engine.cl
@@ -221,7 +221,7 @@ kernel void fractal3D(__global sClPixel *out, __global char *inBuff, __global ch
 
 //------------------ decode texture data -----------
 #ifdef USE_TEXTURES
-		__global char4 *textures[NUMBER_OF_TEXTURES];
+		__global uchar4 *textures[NUMBER_OF_TEXTURES];
 		int2 textureSizes[NUMBER_OF_TEXTURES];
 
 		for (int i = 0; i < NUMBER_OF_TEXTURES; i++)


### PR DESCRIPTION
Fixes "invalid assignment" errors for environment/normal/roughness/displacement/etc maps. Resolves #1035

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1035
-->

### This pullrequest changes
Changed char to uchar, to match uses elsewhere. 
`__global uchar4 *textures[NUMBER_OF_TEXTURES];`